### PR TITLE
Feature - update student from student index and parent student index

### DIFF
--- a/app/views/school_students/index.html.erb
+++ b/app/views/school_students/index.html.erb
@@ -2,7 +2,7 @@
 <%= link_to "Create Student", "/schools/#{@school.id}/students/new" %>
 <%= link_to "Sort Alphabetically", "/schools/#{@school.id}/students?sort=alpha" %>
 <% @students.each do |student| %>
-   <p>Name: <%= student.name %></p>
+   <p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> </p>
    <p>Honor Roll: <%= student.honor_roll %></p>
    <p>Class Rank: <%= student.class_rank %></p>
 <% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -3,7 +3,7 @@
 <%= link_to "Schools", "/schools" %>
 <% @students.each do |student| %>
 <% if student.honor_roll == true %>
-<p>Name: <%= student.name %></p>
+<p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> </p>
 <p>Honor Roll? <%= student.honor_roll %></p>
 <p>Class Rank: <%= student.class_rank %></p>
 <p>School Id: <%= student.school_id %></p>

--- a/spec/features/schools/index_spec.rb
+++ b/spec/features/schools/index_spec.rb
@@ -99,24 +99,25 @@ RSpec.describe 'the school index page' do
 # When I visit the parent index page
 # Next to every parent, I see a link to edit that parent's info
 
-      it 'displays a link to edit the schools info next to every school record' do 
-         monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
+   it 'displays a link to edit the schools info next to every school record' do 
+      monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
                                  ap_program: true)
          
-         visit '/schools'
-         find_link "Update School"
+      visit '/schools'
+      find_link "Update School"
 
-         expect(page).to have_link("Update School")
-      end
+      expect(page).to have_link("Update School")
+   end
 # When I click the link
 # I should be taken to that parents edit page where I can update its information
-      it 'links to the schools edit page' do 
-         monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
+   it 'links to the schools edit page' do 
+      monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
                                  ap_program: true)
-         visit '/schools'
-         click_link "Update School"
+      visit '/schools'
+      click_link "Update School"
 
-         expect(current_path).to eq("/schools/#{monta.id}/edit")
-      end
-   
+      expect(current_path).to eq("/schools/#{monta.id}/edit")
+   end
+
+
 end

--- a/spec/features/schools/students/index_spec.rb
+++ b/spec/features/schools/students/index_spec.rb
@@ -93,4 +93,32 @@ RSpec.describe 'school students index' do
 
       expect(page).to have_link("Sort Alphabetically")
    end
+
+   # us 18
+   # When I visit the `child_table_name` index page
+   # Next to every child, I see a link to edit that child's info
+
+   it 'displays a link to edit each student info' do 
+      school = School.create!(name: "Lemonade High School", national_rank: 12, 
+                              ap_program: true)
+      mandy = school.students.create!(name: "Mandy", honor_roll: true, class_rank: 4)
+      noah = school.students.create!(name: "Noah", honor_roll: false, class_rank: 29) 
+
+      visit "/schools/#{school.id}/students"
+      find_link("Update Student", match: :first)
+
+      expect(page).to have_link("Update Student")
+      # expect(current_path).to eq("/students/#{mandy.id}/edit")
+   end
+
+   it 'links to the students edit page' do 
+      monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
+                              ap_program: true)
+      mandy = monta.students.create!(name: "Mandy", honor_roll: true, class_rank: 4)
+
+      visit "/schools/#{monta.id}/students"
+      click_link "Update Student"
+
+      expect(current_path).to eq("/students/#{mandy.id}/edit")
+   end
 end

--- a/spec/features/students/index_spec.rb
+++ b/spec/features/students/index_spec.rb
@@ -112,4 +112,31 @@ RSpec.describe 'the student index page' do
         expect(page).to have_content("Mandy")
         expect(page).to_not have_content("Noah")
     end
+
+#    user story 18
+#    When I visit the `child_table_name` index page
+#    Next to every child, I see a link to edit that child's info
+
+    it 'displays a link to edit each student info' do 
+        school = School.create!(name: "Lemonade High School", national_rank: 12, 
+                                ap_program: true)
+        mandy = school.students.create!(name: "Mandy", honor_roll: true, class_rank: 4)
+        noah = school.students.create!(name: "Noah", honor_roll: false, class_rank: 29) 
+
+        visit '/students'
+        find_link("Update Student")
+
+        expect(page).to have_link("Update Student")
+    end
+
+    it 'links to the students edit page' do 
+        monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
+                                ap_program: true)
+        mandy = monta.students.create!(name: "Mandy", honor_roll: true, class_rank: 4)
+
+        visit '/students'
+        click_link "Update Student"
+
+        expect(current_path).to eq("/students/#{mandy.id}/edit")
+    end
 end

--- a/spec/features/students/index_spec.rb
+++ b/spec/features/students/index_spec.rb
@@ -128,7 +128,8 @@ RSpec.describe 'the student index page' do
 
         expect(page).to have_link("Update Student")
     end
-
+#   When I click the link
+#    I should be taken to that `child_table_name` edit page where I can update its information
     it 'links to the students edit page' do 
         monta = School.create!(name: "Monta Vista High School", national_rank: 12, 
                                 ap_program: true)


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_

As a visitor
When I visit the `student` index page or a `school students index page`
Next to every student, I see a link to edit that student's info
When I click the link
I should be taken to that particular `student` edit page where I can update its information

## Solution
_How did you solve the problem?_

Using TDD:

- First feature tested displaying and clicking link to edit student info from student index
- Update html index to render this view
- Added another feature test for the same but from the school student index page
- Updated appropriate view file

## Other changes (e.g. bug fixes, UI tweaks, small refactors)

Capybara error - ambiguity; Updated my feature test to find the first link that matches

## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary