### PR TITLE
CRUD - school delete

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -26,6 +26,12 @@ class SchoolsController < ApplicationController
         redirect_to "/schools/#{@school.id}"
     end
 
+    def destroy 
+        school = School.find(params[:id])
+        school.destroy
+        redirect_to "/schools"
+    end
+
 private
     def school_params 
         params.permit(:name, :national_rank, :ap_program)

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,5 +1,5 @@
 class School < ApplicationRecord
-   has_many :students 
+   has_many :students, dependent: :destroy
    validates_presence_of :name
    validates_presence_of :national_rank
    validates :ap_program, inclusion: [true, false]

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -2,6 +2,7 @@
 <%= link_to "Schools", "/schools" %>
 <%= link_to "Roster", "/schools/#{@school.id}/students" %>
 <%= link_to "Update School", "/schools/#{@school.id}/edit" %>
+<%= link_to "Delete School", "/schools/#{@school.id}", method: :delete %>
 
 <h1><%= @school.name %></h1>
 <p>National Rank: <%= @school.national_rank %></p>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -4,7 +4,7 @@
 <% @students.each do |student| %>
 <% if student.honor_roll == true %>
 <p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> </p>
-<p>Honor Roll? <%= student.honor_roll %></p>
+<p>Honor Roll <%= student.honor_roll %></p>
 <p>Class Rank: <%= student.class_rank %></p>
 <p>School Id: <%= student.school_id %></p>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,5 @@ Rails.application.routes.draw do
   get '/schools/:id/edit', to: 'schools#edit'
   patch '/schools/:id', to: 'schools#update'
   patch '/students/:id', to: 'students#update'
+  delete '/schools/:id', to: 'schools#destroy'
 end

--- a/spec/features/schools/show_spec.rb
+++ b/spec/features/schools/show_spec.rb
@@ -114,6 +114,34 @@ RSpec.describe 'the schools show page' do
 
       expect(page).to have_link("Update School")
    end
+
+# User story 19 - When I visit a parent show page
+# Then I see a link to delete the parent
+# When I click the link "Delete Parent"
+# Then a 'DELETE' request is sent to '/parents/:id',
+# the parent is deleted, and all child records are deleted
+# and I am redirected to the parent index page where I no longer see this parent
+
+   it 'displays a link to delete the school from that school show page' do 
+      school = School.create!(name: "Lemonade High School", national_rank: 12, 
+                                 ap_program: true)
+
+      visit "/schools/#{school.id}"
+      find_link "Delete School"
+
+      expect(page).to have_link("Delete School")
+   end
+
+   it 'deletes the school' do 
+      school = School.create!(name: "Lemonade High School", national_rank: 12, 
+                                 ap_program: true)
+      
+      visit "/schools/#{school.id}"
+      click_link "Delete School"
+
+      expect(current_path).to eq("/schools")
+   end
+
 end
       
 


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_

User story 19 - 
When I visit a `school show page`
Then I see a` link to delete` the school
When I `click the link "Delete School"`
Then a `'DELETE' `request is sent to `'/schools/:id'`,
the school is deleted, and all student records are deleted
and I am redirected to the `school index page `where I no longer see this school

## Solution
_How did you solve the problem?_

Using TDD:

- Feature test in `school show spec `displays link and redirects as expected
- `link to `delete feature in html view, specifying `method: :delete`
- added a `DELETE `route
- included a destroy method in `schoolscontroller` with a redirect route to `school index `page 
- updated `school model` to include a `dependent: :destroy `relationship to students

## Other changes (e.g. bug fixes, UI tweaks, small refactors)
## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary