### PR TITLE
Feature - Delete Student from Student Index/School Student Index

### DIFF
--- a/app/views/school_students/index.html.erb
+++ b/app/views/school_students/index.html.erb
@@ -2,7 +2,8 @@
 <%= link_to "Create Student", "/schools/#{@school.id}/students/new" %>
 <%= link_to "Sort Alphabetically", "/schools/#{@school.id}/students?sort=alpha" %>
 <% @students.each do |student| %>
-   <p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> </p>
+   <p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> 
+   <%= link_to "Delete Student", "/students/", method: :delete %> </p>
    <p>Honor Roll: <%= student.honor_roll %></p>
    <p>Class Rank: <%= student.class_rank %></p>
 <% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -3,7 +3,8 @@
 <%= link_to "Schools", "/schools" %>
 <% @students.each do |student| %>
 <% if student.honor_roll == true %>
-<p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> </p>
+<p>Name: <%= student.name %> <%= link_to "Update Student", "/students/#{student.id}/edit" %> 
+<%= link_to "Delete Student", "/students/#{student.id}", method: :delete %> </p>
 <p>Honor Roll <%= student.honor_roll %></p>
 <p>Class Rank: <%= student.class_rank %></p>
 <p>School Id: <%= student.school_id %></p>

--- a/spec/features/schools/students/index_spec.rb
+++ b/spec/features/schools/students/index_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe 'school students index' do
 # Then I see a link to sort children in alphabetical order 
 
    it 'displays a link to sort students in alphabetical order' do 
-         school = School.create!(name: "Lemonade High School", national_rank: 12, 
+      school = School.create!(name: "Lemonade High School", national_rank: 12, 
                                  ap_program: true)
       school_2 = School.create!(name: "Watermelon High School", national_rank: 19,
                                     ap_program: false)                          
@@ -120,5 +120,17 @@ RSpec.describe 'school students index' do
       click_link "Update Student"
 
       expect(current_path).to eq("/students/#{mandy.id}/edit")
+   end
+
+   it 'displays a link to delete each student' do 
+      school = School.create!(name: "Lemonade High School", national_rank: 12, 
+                              ap_program: true)
+      mandy = school.students.create!(name: "Mandy", honor_roll: true, class_rank: 4)
+      noah = school.students.create!(name: "Noah", honor_roll: false, class_rank: 29) 
+
+      visit "/schools/#{school.id}/students"
+      find_link("Delete Student", match: :first)
+
+      expect(page).to have_link("Delete Student")
    end
 end

--- a/spec/features/students/index_spec.rb
+++ b/spec/features/students/index_spec.rb
@@ -140,4 +140,21 @@ RSpec.describe 'the student index page' do
 
         expect(current_path).to eq("/students/#{mandy.id}/edit")
     end
+
+    # As a visitor - user story 23
+    # When I visit the `student index page or a school student index page
+    # Next to every child, I see a link to delete that child
+    # When I click the link
+    # I should be taken to the `school` index page where I no longer see that child
+    it 'displays a link to delete each student' do 
+        school = School.create!(name: "Lemonade High School", national_rank: 12, 
+                                ap_program: true)
+        mandy = school.students.create!(name: "Mandy", honor_roll: true, class_rank: 4)
+        noah = school.students.create!(name: "Noah", honor_roll: false, class_rank: 29) 
+
+        visit '/students'
+        click_link("Delete Student")
+
+        expect(current_path).to eq("/students")
+    end
 end


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_
User Story 23 - 
As a visitor
When I visit the `student` index page or a `school_student` index page
Next to every `student` I see a `link to delete` that student
When I click the link
I should be taken to the `student` index page where I no longer see that child

## Solution
_How did you solve the problem?_

Using TDD:

- feature tests for links to delete student, both on student index and school student index page
- rendered html view and included a matching condition so capybara would not give ambiguity error

## Other changes (e.g. bug fixes, UI tweaks, small refactors)
## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary